### PR TITLE
修正数据分箱错误

### DIFF
--- a/candlestick_chart.go
+++ b/candlestick_chart.go
@@ -117,7 +117,7 @@ func NewCandlestickChart(period Period, timeRange map[time.Time]*DayTime, loc *t
 }
 
 func (chart *CandlestickChart) AddEmpty(t time.Time) error {
-	x, err := chart.timeSeries.ToX(t)
+	x, err := chart.timeSeries.NextX(t)
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func (chart *CandlestickChart) AddEmpty(t time.Time) error {
 
 func (chart *CandlestickChart) AddTrade(t time.Time, value decimal.Decimal, volume int64) error {
 	res := make([]*Candlestick, 0)
-	x, err := chart.timeSeries.ToX(t)
+	x, err := chart.timeSeries.NextX(t)
 	if err != nil {
 		return err
 	}

--- a/candlestick_chart.go
+++ b/candlestick_chart.go
@@ -14,7 +14,7 @@ type Period uint8
 const (
 	PeriodMinute Period = iota
 	PeriodFiveMinute
-	PeriodQuatorHour
+	PeriodQuarterHour
 	PeriodHalfHour
 	PeriodHour
 	PeriodDay
@@ -101,7 +101,7 @@ func NewCandlestickChart(period Period, timeRange map[time.Time]*DayTime, loc *t
 				timer.Stop()
 			case <-timer.C:
 				now := time.Now()
-				chart.AddEmpty(now.Add(-time.Minute))
+				_ = chart.AddEmpty(now.Add(-time.Minute))
 				nx, err := chart.timeSeries.NextX(now)
 				if err != nil {
 					fmt.Println(err)
@@ -217,19 +217,27 @@ func (ts *TimeSeries) toX(t time.Time) time.Time {
 	case PeriodMinute:
 		return t.Truncate(time.Minute)
 	case PeriodFiveMinute:
-		return t.Truncate(time.Minute).Round(5 * time.Minute)
-	case PeriodQuatorHour:
-		return t.Truncate(time.Minute).Round(15 * time.Minute)
+		return t.Truncate(5 * time.Minute)
+	case PeriodQuarterHour:
+		return t.Truncate(15 * time.Minute)
 	case PeriodHalfHour:
-		return t.Truncate(time.Minute).Round(30 * time.Minute)
+		return t.Truncate(30 * time.Minute)
 	case PeriodHour:
-		return t.Truncate(time.Minute).Round(time.Hour)
+		return t.Truncate(time.Hour)
 	case PeriodDay:
 		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, ts.loc)
+	case PeriodWeek:
+		offset := t.Weekday() - 1
+		if offset < 0 {
+			offset = 6
+		}
+		nt := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, ts.loc)
+		nt = nt.Add(time.Duration(-offset) * 24 * time.Hour)
+		return nt
 	case PeriodMonth:
-		return time.Date(t.Year(), t.Month(), 0, 0, 0, 0, 0, ts.loc)
+		return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, ts.loc)
 	case PeriodYear:
-		return time.Date(t.Year(), 0, 0, 0, 0, 0, 0, ts.loc)
+		return time.Date(t.Year(), 1, 1, 0, 0, 0, 0, ts.loc)
 	default:
 		return t.Truncate(time.Minute)
 	}
@@ -242,7 +250,7 @@ func (ts *TimeSeries) NextX(t time.Time) (time.Time, error) {
 		x = x.Add(time.Minute)
 	case PeriodFiveMinute:
 		x = x.Add(5 * time.Minute)
-	case PeriodQuatorHour:
+	case PeriodQuarterHour:
 		x = x.Add(15 * time.Minute)
 	case PeriodHalfHour:
 		x = x.Add(30 * time.Minute)
@@ -250,6 +258,8 @@ func (ts *TimeSeries) NextX(t time.Time) (time.Time, error) {
 		x = x.Add(time.Hour)
 	case PeriodDay:
 		x = time.Date(t.Year(), t.Month(), t.Day()+1, 0, 0, 0, 0, ts.loc)
+	case PeriodWeek:
+		x = time.Date(t.Year(), t.Month(), t.Day()+7, 0, 0, 0, 0, ts.loc)
 	case PeriodMonth:
 		x = time.Date(t.Year(), t.Month()+1, 0, 0, 0, 0, 0, ts.loc)
 	case PeriodYear:

--- a/candlestick_chart_test.go
+++ b/candlestick_chart_test.go
@@ -2,7 +2,6 @@ package candlestick
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 
 	// "os"
@@ -62,12 +61,13 @@ func TestChart(t *testing.T) {
 			"delay": 113, "value": 23, "volume": 35,
 		},
 	}
+	log.Println("market is opening..")
 	for _, tx := range txs {
 		go trade(chart, tx)
 	}
 	time.Sleep(5 * time.Minute)
 	b, _ := json.Marshal(chart.candlesticks)
-	fmt.Println(string(b))
+	log.Println(string(b))
 }
 
 func trade(chart *CandlestickChart, tx map[string]any) {

--- a/candlestick_chart_test.go
+++ b/candlestick_chart_test.go
@@ -16,9 +16,9 @@ import (
 
 func TestChart(t *testing.T) {
 	m := map[time.Time]*DayTime{
-		time.Date(2022, time.August, 8, 0, 0, 0, 0, time.UTC): {
-			Start: time.Date(2022, time.August, 8, 0, 0, 0, 0, time.UTC),
-			End:   time.Date(2022, time.August, 8, 24, 0, 0, 0, time.UTC),
+		time.Date(2023, time.July, 27, 0, 0, 0, 0, time.UTC): {
+			Start: time.Date(2023, time.July, 27, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2023, time.July, 27, 24, 0, 0, 0, time.UTC),
 		},
 	}
 	chart, err := NewCandlestickChart(PeriodMinute, m, time.UTC)
@@ -28,15 +28,72 @@ func TestChart(t *testing.T) {
 	defer chart.Stop()
 	chart.WatchFunc(func(c *Candlestick) {
 		b, _ := json.Marshal(c)
-		fmt.Printf("watch:%s\n", string(b))
+		log.Printf("watch:%s\n", string(b))
 	})
-	chart.AddTrade(time.Now().UTC(), decimal.NewFromInt(12), 1)
-
-	time.Sleep(1 * time.Minute)
-	chart.AddTrade(time.Now().UTC(), decimal.NewFromInt(11), 1)
-	time.Sleep(2 * time.Minute)
-	chart.AddTrade(time.Now().UTC(), decimal.NewFromInt(14), 1)
-
+	txs := []map[string]any{
+		{
+			"delay": 10, "value": 12, "volume": 1,
+		},
+		{
+			"delay": 22, "value": 23, "volume": 1,
+		},
+		{
+			"delay": 31, "value": 45, "volume": 2,
+		},
+		{
+			"delay": 44, "value": 15, "volume": 6,
+		},
+		{
+			"delay": 55, "value": 33, "volume": 34,
+		},
+		{
+			"delay": 66, "value": 47, "volume": 347,
+		},
+		{
+			"delay": 71, "value": 52, "volume": 42,
+		},
+		{
+			"delay": 92, "value": 12, "volume": 14,
+		},
+		{
+			"delay": 102, "value": 24, "volume": 246,
+		},
+		{
+			"delay": 113, "value": 23, "volume": 35,
+		},
+	}
+	for _, tx := range txs {
+		go trade(chart, tx)
+	}
+	time.Sleep(5 * time.Minute)
 	b, _ := json.Marshal(chart.candlesticks)
 	fmt.Println(string(b))
+}
+
+func trade(chart *CandlestickChart, tx map[string]any) {
+	delay := tx["delay"].(int)
+	value := tx["value"].(int)
+	volume := tx["volume"].(int)
+	time.Sleep(time.Duration(delay) * time.Second)
+	_ = chart.AddTrade(time.Now().UTC(), decimal.NewFromInt(int64(value)), int64(volume))
+}
+
+func TestToX(t *testing.T) {
+	ti := time.Now()
+	log.Println(ti.Truncate(time.Minute))
+	log.Println(ti.Truncate(5 * time.Minute))
+	log.Println(ti.Truncate(10 * time.Minute))
+	log.Println(ti.Truncate(15 * time.Minute))
+	log.Println(ti.Truncate(30 * time.Minute))
+	log.Println(ti.Truncate(time.Hour))
+	log.Println(time.Date(ti.Year(), ti.Month(), ti.Day(), 0, 0, 0, 0, ti.Location()))
+	offset := ti.Weekday() - 1
+	if offset < 0 {
+		offset = 6
+	}
+	nt := time.Date(ti.Year(), ti.Month(), ti.Day(), 0, 0, 0, 0, ti.Location())
+	nt = nt.Add(time.Duration(-offset) * 24 * time.Hour)
+	log.Println(nt)
+	log.Println(time.Date(ti.Year(), ti.Month(), 1, 0, 0, 0, 0, ti.Location()))
+	log.Println(time.Date(ti.Year(), 1, 1, 0, 0, 0, 0, ti.Location()))
 }


### PR DESCRIPTION
1. 原始代码中对时间所属bin分箱采用time.Round，导致四舍五入的效果。

    e.g.
    ```golang
    case PeriodFiveMinute:
    return t.Truncate(time.Minute).Round(5 * time.Minute)
    ```

    依据：
        `雪球` 及 `东方财富网` 的行情与 `长桥` 统计值存在出入，体现在成交量、成交金额等。如图：
        ![未命名](https://github.com/longbridgeapp/candlestick-go/assets/11806577/93fadab4-455f-421e-9da1-3df2cb452365)


2. 将蜡烛图中的时间label更正为该蜡烛结束时间。
3. 完成以周为界的蜡烛。